### PR TITLE
WIP - Normalize the monetary value of the events

### DIFF
--- a/compensated-ruby/lib/compensated/gumroad/event_parser.rb
+++ b/compensated-ruby/lib/compensated/gumroad/event_parser.rb
@@ -21,7 +21,7 @@ module Compensated
           raw_event_type: request.data["resource_name"].to_sym,
           raw_event_id: nil,
           payment_processor: :gumroad,
-          value: {amount: request.data["price"].to_i, currency: request.data["currency"].upcase},
+          amount: {paid: request.data["price"].to_i, currency: request.data["currency"].upcase},
         }
       end
     end

--- a/compensated-ruby/lib/compensated/stripe/event_parser.rb
+++ b/compensated-ruby/lib/compensated/stripe/event_parser.rb
@@ -13,13 +13,12 @@ module Compensated
           raw_event_type: request.data[:type].to_sym,
           raw_event_id: request.data[:id],
           payment_processor: :stripe,
-          value: value(request),
+          amount: amount(request),
         }
       end
 
-      private def value(request)
+      private def amount(request)
         {
-          amount: amount(request),
           currency: request.data[:data][:object][:currency].upcase,
           due: due(request),
           paid: paid(request),
@@ -28,7 +27,8 @@ module Compensated
       end
 
       private def paid(request)
-        request.data.fetch(:data, {}).fetch(:object, {}).fetch(:amount_paid, nil)
+        return request.data[:data][:object][:amount_paid] if invoice?(request)
+        request.data[:data][:object][:amount]
       end
 
       private def remaining(request)
@@ -37,11 +37,6 @@ module Compensated
 
       private def due(request)
         request.data.fetch(:data, {}).fetch(:object, {}).fetch(:amount_due, nil)
-      end
-
-      private def amount(request)
-        return request.data[:data][:object][:amount_paid] if invoice?(request)
-        request.data[:data][:object][:amount]
       end
 
       private def invoice?(request)

--- a/compensated-ruby/spec/gumroad/event_parser_spec.rb
+++ b/compensated-ruby/spec/gumroad/event_parser_spec.rb
@@ -35,7 +35,7 @@ module Compensated
           it { is_expected.to include raw_event_type: :sale }
           it { is_expected.to include raw_event_id: nil }
           it { is_expected.to include payment_processor: :gumroad }
-          it { is_expected.to include({value: {amount: 20_00, currency: "USD"}}) }
+          it { is_expected.to include({amount: {paid: 20_00, currency: "USD"}}) }
         end
       end
     end

--- a/compensated-ruby/spec/stripe/event_parser_spec.rb
+++ b/compensated-ruby/spec/stripe/event_parser_spec.rb
@@ -38,7 +38,7 @@ module Compensated
           it { is_expected.to include raw_event_type: :"charge.succeeded" }
           it { is_expected.to include raw_event_id: request.data[:id] }
           it { is_expected.to include payment_processor: :stripe }
-          it { is_expected.to include value: {amount: 4_00, currency: "USD"} }
+          it { is_expected.to include amount: {paid: 4_00, currency: "USD"} }
         end
 
         context "when the input event is JSON parsed from a Stripe invoice.payment_succeeded event from Stripe API v2014-11-05" do
@@ -48,8 +48,7 @@ module Compensated
           it { is_expected.to include raw_event_id: request.data[:id] }
           it { is_expected.to include payment_processor: :stripe }
           it {
-            is_expected.to include value: {
-              amount: 0_0,
+            is_expected.to include amount: {
               due: 0_0,
               paid: 0_0,
               remaining: 0_0,


### PR DESCRIPTION
We want to expose the $$$ amount in a way that will play nicely with other libraries like [RubyMoney](https://github.com/RubyMoney/money). I'm not entirely convinced that we want the data to be a child object just yet, but I'd rather start with a child node than start having to namespace the top-level attributes.