### PR TITLE
Developer may Rehydrate Gumroad Events may be rehydrated without a HTTP Request

### DIFF
--- a/compensated-ruby/lib/compensated/gumroad/event_parser.rb
+++ b/compensated-ruby/lib/compensated/gumroad/event_parser.rb
@@ -1,3 +1,4 @@
+require "webrick"
 module Compensated
   module Gumroad
     class EventParser
@@ -8,29 +9,41 @@ module Compensated
         keys.include?(:seller_id) && keys.include?(:product_id) && keys.include?(:product_permalink) && request.data["product_permalink"].include?("gum.co")
       end
 
-      def parse(request)
-        if request.body.respond_to?(:read)
-          body = request.body.read
-          request.body.rewind
-        else
-          body = request.body
-        end
-
+      def normalize(data_or_body)
+        data = data_or_body.respond_to?(:key) ? data_or_body : data_from_string(data_or_body)
+        body = data_or_body.respond_to?(:key) ? nil : data_or_body
         {
           raw_body: body,
-          raw_event_type: request.data["resource_name"].to_sym,
+          raw_event_type: data["resource_name"].to_sym,
           raw_event_id: nil,
           payment_processor: :gumroad,
           amount: {
-            paid: request.data["price"].to_i,
-            currency: request.data["currency"].upcase,
+            paid: data["price"].to_i,
+            currency: data["currency"].upcase,
           },
           customer: {
-            id: request.data["purchaser_id"].to_s,
-            email: request.data["email"],
-            name: request.data["full_name"],
+            id: data["purchaser_id"].to_s,
+            email: data["email"],
+            name: data["full_name"],
           },
-        }
+        }.compact
+      end
+
+      def parse(request)
+        normalize(request.body)
+      end
+
+      private def read_and_rewind(body)
+        if body.respond_to?(:read)
+          body = body.read
+          body.rewind
+        else
+          body
+        end
+      end
+
+      private def data_from_string(body)
+        WEBrick::HTTPUtils.parse_query(read_and_rewind(body))
       end
     end
     Compensated.event_parsers.push(Gumroad::EventParser.new)

--- a/compensated-ruby/spec/gumroad/event_parser_spec.rb
+++ b/compensated-ruby/spec/gumroad/event_parser_spec.rb
@@ -4,9 +4,17 @@ module Compensated
   module Gumroad
     RSpec.describe EventParser do
       def fake_request(fixture)
-        content = fixture.nil? ? nil : File.read(File.join(__dir__, "fixtures", fixture))
-        data = Rack::Utils.default_query_parser.parse_query(content)
+        content = fixture_content(fixture)
+        data = fixture_data(fixture)
         PaymentProcessorEventRequest.new(double(form_data?: true, params: data, body: content))
+      end
+
+      def fixture_content(fixture)
+        fixture.nil? ? nil : File.read(File.join(__dir__, "fixtures", fixture))
+      end
+
+      def fixture_data(fixture)
+        Rack::Utils.default_query_parser.parse_query(fixture_content(fixture))
       end
 
       it "Adds itself to the list of event parses available to compensated" do
@@ -14,6 +22,30 @@ module Compensated
       end
 
       subject(:event_parser) { EventParser.new }
+
+      describe "#normalize(body_or_data)" do
+        subject(:data) { event_parser.normalize(body_or_data) }
+        context "when it's a string of body data" do
+          let(:body_or_data) { fixture_content("sample-ping.as.multipart") }
+          it { is_expected.to include raw_body: body_or_data }
+          it { is_expected.to include raw_event_type: :sale }
+          it { is_expected.not_to have_key(:raw_event_id) }
+          it { is_expected.to include payment_processor: :gumroad }
+          it { is_expected.to include({amount: {paid: 20_00, currency: "USD"}}) }
+          it { is_expected.to include({customer: {id: "5312883333252", email: "customer@example.com", name: "Foo Bar"}}) }
+        end
+
+        context "when it's a hash of that data" do
+          let(:body_or_data) { fixture_data("sample-ping.as.multipart") }
+          it { is_expected.not_to have_key(:raw_body) }
+          it { is_expected.to include raw_event_type: :sale }
+          it { is_expected.not_to have_key(:raw_event_id) }
+          it { is_expected.to include payment_processor: :gumroad }
+          it { is_expected.to include({amount: {paid: 20_00, currency: "USD"}}) }
+          it { is_expected.to include({customer: {id: "5312883333252", email: "customer@example.com", name: "Foo Bar"}}) }
+        end
+      end
+
       describe "#parses?(request)" do
         subject(:parses?) { event_parser.parses?(request) }
         context "when the request data is nil" do
@@ -33,7 +65,7 @@ module Compensated
           let(:request) { fake_request("sample-ping.as.multipart") }
           it { is_expected.to include raw_body: request.body }
           it { is_expected.to include raw_event_type: :sale }
-          it { is_expected.to include raw_event_id: nil }
+          it { is_expected.not_to have_key(:raw_event_id) }
           it { is_expected.to include payment_processor: :gumroad }
           it { is_expected.to include({amount: {paid: 20_00, currency: "USD"}}) }
           it { is_expected.to include({customer: {id: "5312883333252", email: "customer@example.com", name: "Foo Bar"}}) }


### PR DESCRIPTION
Similar to Stripe, we need to be able to re-capture data from the body
without the baggage of the HTTP request.

See #7 