### PR TITLE
Resolve parsing error when normalizing gumroad data from rewindable IO objects

### DIFF
--- a/compensated-ruby/lib/compensated/gumroad/event_parser.rb
+++ b/compensated-ruby/lib/compensated/gumroad/event_parser.rb
@@ -11,7 +11,7 @@ module Compensated
 
       def normalize(data_or_body)
         data = data_or_body.respond_to?(:key) ? data_or_body : data_from_string(data_or_body)
-        body = data_or_body.respond_to?(:key) ? nil : data_or_body
+        body = data_or_body.respond_to?(:key) ? nil : read_and_rewind(data_or_body)
         {
           raw_body: body,
           raw_event_type: data["resource_name"].to_sym,
@@ -35,8 +35,9 @@ module Compensated
 
       private def read_and_rewind(body)
         if body.respond_to?(:read)
-          body = body.read
+          read_value = body.read
           body.rewind
+          read_value
         else
           body
         end

--- a/compensated-ruby/spec/gumroad/event_parser_spec.rb
+++ b/compensated-ruby/spec/gumroad/event_parser_spec.rb
@@ -13,6 +13,10 @@ module Compensated
         fixture.nil? ? nil : File.read(File.join(__dir__, "fixtures", fixture))
       end
 
+      def fixture_io(fixture)
+        fixture.nil? ? nil : File.open(File.join(__dir__, "fixtures", fixture))
+      end
+
       def fixture_data(fixture)
         Rack::Utils.default_query_parser.parse_query(fixture_content(fixture))
       end
@@ -38,6 +42,16 @@ module Compensated
         context "when it's a hash of that data" do
           let(:body_or_data) { fixture_data("sample-ping.as.multipart") }
           it { is_expected.not_to have_key(:raw_body) }
+          it { is_expected.to include raw_event_type: :sale }
+          it { is_expected.not_to have_key(:raw_event_id) }
+          it { is_expected.to include payment_processor: :gumroad }
+          it { is_expected.to include({amount: {paid: 20_00, currency: "USD"}}) }
+          it { is_expected.to include({customer: {id: "5312883333252", email: "customer@example.com", name: "Foo Bar"}}) }
+        end
+
+        context "when it's a IO object" do
+          let(:body_or_data) { fixture_io("sample-ping.as.multipart") }
+          it { is_expected.to include raw_body: body_or_data.read }
           it { is_expected.to include raw_event_type: :sale }
           it { is_expected.not_to have_key(:raw_event_id) }
           it { is_expected.to include payment_processor: :gumroad }


### PR DESCRIPTION
Since the data may be coming in as an IO object, we need to be able to
read and rewind it and use the read value throughout the parsed object.

This is making me think it's about time to create an `ParsedEvent`
object that can keep that state in it; but I think that's a bigger
refactor than I have time for today.