### PR TITLE
📝 Contributors are recognized within `CREDITS.md`

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,6 @@
+# Credits
+
+| #   | Handle                                  | Affiliation                                                                    | Notes/Role                             |
+| --- | --------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------- |
+| 1.  | [zspencer](https://github.com/zspencer) | Executive Director of Community ([Zinc Collective LLC](https://www.zinc.coop)) | Benevolent Dictator (for now)          |
+| 2.  | [drllau](https://github.com/drllau)     | IP Broker ([Gemwise Invests](https://www.linkedin.com/in/drllau/))             | Feedback on Licensing and Pricing RFCs |

--- a/core/LICENSE/CREDITS.md
+++ b/core/LICENSE/CREDITS.md
@@ -1,5 +1,0 @@
-# Credits
-
-|  #  | Handle    | Affiliation | Notes/Role  |
-| --- | --------- | ----------- | ----------- |
-| 1. | [zspencer](https://github.com/zspencer) | Executive Director Community ([Zinc Cooperative, Ltd](https://www.zinc.coop)) | Benevolent Dictator for now |


### PR DESCRIPTION
I like the addition of the `CREDITS.md` file, and was
unsure if there was a convention between that and `CONTRIBUTORS.md`.

I looked here:
https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file

But didn't find one; so I'm going to leave it as CREDITS for now and put it at the top level.

I've also added @drllau's credit!