### PR TITLE
Add more full support for canceled/ended

### DIFF
--- a/compensated-ruby/compensated.gemspec
+++ b/compensated-ruby/compensated.gemspec
@@ -38,6 +38,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "mustache", "~> 1.0"
   spec.add_development_dependency "rack"
 end

--- a/compensated-ruby/compensated.gemspec
+++ b/compensated-ruby/compensated.gemspec
@@ -38,5 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "mustache", "~> 1.0"
   spec.add_development_dependency "rack"
 end

--- a/compensated-ruby/lib/compensated/stripe/event_parser.rb
+++ b/compensated-ruby/lib/compensated/stripe/event_parser.rb
@@ -65,7 +65,9 @@ module Compensated
           purchased: purchased(data),
           description: line[:description],
           quantity: line[:quantity],
-          # TODO: Deprecate!
+          # TODO: Deprecate `expiration` as it now lives on subscription!
+          #       BUT people are using `expiration` so let's figure out
+          #       a way to safely remove it.
           expiration: period_end(line, data),
           subscription: subscription(line, data),
           plan: plan(line)
@@ -121,8 +123,11 @@ module Compensated
       end
 
       private def purchased(data)
-        string = data[:data][:object][:created] if data[:data][:object][:created]
-        string ||= data[:data][:object][:status_transitions][0][:paid_at]
+        string = if data[:data][:object][:created]
+            data[:data][:object][:created]
+          else
+            data[:data][:object][:status_transitions][0][:paid_at]
+          end
         return nil if string.nil?
         Time.at(string)
       end

--- a/compensated-ruby/spec/fixtures.rb
+++ b/compensated-ruby/spec/fixtures.rb
@@ -51,11 +51,11 @@ module Compensated
       # @param default [Object] Default value if key is missing
       # @return [Object], never returns nil, preferring "null"  for JSON compatibility.
       def value(within:, default: nil)
-        value = dig(within: within, default: default)
+        value = dig_with_default(within: within, default: default)
         value.nil? ? "null" : value
       end
 
-      protected def dig(within:, default: nil)
+      protected def dig_with_default(within:, default: nil)
         within.reduce(data) do |result, key|
           return default unless result.key?(key)
           result.fetch(key, {})

--- a/compensated-ruby/spec/fixtures.rb
+++ b/compensated-ruby/spec/fixtures.rb
@@ -1,12 +1,66 @@
 require 'erb'
 module Compensated
-  module Fixtures
-    module TemplateHelpers
-      def template(adapter, fixture, interpolate: {})
-        uninterpolated_body = fixture.nil? ? nil : File.open(File.join(adapter, "fixtures", fixture)).read
-        return uninterpolated_body if uninterpolated_body.nil?
-        interpolated_body = ERB.new(uninterpolated_body).result_with_hash(interpolate: interpolate)
-        StringIO.new(interpolated_body)
+  module Spec
+    module Helpers
+
+      # @param template_path [String, Path] Absolute path to template file
+      # @return PaymentProcessorEventRequest
+      def fake_request(template_path, interpolate: {})
+        body = template(template_path, interpolate: interpolate)
+        PaymentProcessorEventRequest.new(double(form_data?: false, body: body))
+      end
+
+      # @param adapter_path [String,Path] Absolute path to adapter directory
+      # @param fixture [String] name of fixture file
+      # @return Path Absolute path of fixture within the adapter's fixtures directory
+      def fixture_path(adapter_path, fixture)
+        File.join(adapter_path, "fixtures", fixture)
+      end
+
+      # Interpolates data against an ERB template.
+      #
+      # @param template_path [String, Path] Absolute path to template file
+      # @param interpolate: [Hash] Hash with data to interpolate
+      # @return [StringIO]
+      def template(template_path, interpolate: {})
+        return nil if template_path.nil?
+        interpolator = Interpolator.new(data: interpolate, template_path: template_path)
+
+        StringIO.new(interpolator.result)
+      end
+    end
+
+
+
+    # Interpolates data against an ERB template
+    class Interpolator
+      attr_accessor :data, :template_path
+      def initialize(data:, template_path:)
+        @data = data
+        @template_path = template_path
+      end
+
+      # @return [String] interpolated result of applying the data to the template
+      def result
+        ERB.new(template).result(binding)
+      end
+
+      # Digs through the data to get a value, falling back to default.
+      #
+      # @param within [Array<Object>] Keys to dig through to get the value
+      # @param default [Object] Default value if key is missing
+      # @return [Object], never returns nil, preferring "null"  for JSON compatibility.
+      def value(within:, default: nil)
+        value = within.reduce(data) do |result, key|
+          return default unless result.key?(key)
+          result.fetch(key, {})
+        end
+
+        value.nil? ? "null" : value
+      end
+
+      private def template
+        @template = File.open(template_path).read
       end
     end
   end

--- a/compensated-ruby/spec/fixtures.rb
+++ b/compensated-ruby/spec/fixtures.rb
@@ -1,0 +1,13 @@
+require 'erb'
+module Compensated
+  module Fixtures
+    module TemplateHelpers
+      def template(adapter, fixture, interpolate: {})
+        uninterpolated_body = fixture.nil? ? nil : File.open(File.join(adapter, "fixtures", fixture)).read
+        return uninterpolated_body if uninterpolated_body.nil?
+        interpolated_body = ERB.new(uninterpolated_body).result_with_hash(interpolate: interpolate)
+        StringIO.new(interpolated_body)
+      end
+    end
+  end
+end

--- a/compensated-ruby/spec/fixtures.rb
+++ b/compensated-ruby/spec/fixtures.rb
@@ -51,12 +51,15 @@ module Compensated
       # @param default [Object] Default value if key is missing
       # @return [Object], never returns nil, preferring "null"  for JSON compatibility.
       def value(within:, default: nil)
-        value = within.reduce(data) do |result, key|
+        value = dig(within: within, default: default)
+        value.nil? ? "null" : value
+      end
+
+      protected def dig(within:, default: nil)
+        within.reduce(data) do |result, key|
           return default unless result.key?(key)
           result.fetch(key, {})
         end
-
-        value.nil? ? "null" : value
       end
 
       private def template

--- a/compensated-ruby/spec/spec_helper.rb
+++ b/compensated-ruby/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require "compensated"
+require_relative 'fixtures'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/compensated-ruby/spec/stripe/event_parser_spec.rb
+++ b/compensated-ruby/spec/stripe/event_parser_spec.rb
@@ -225,7 +225,30 @@ module Compensated
         end
 
 
+        context "when the input event is JSON parsed from a Stripe customer.subscription.updated event from Stripe API v2019-12-03" do
+          let(:fixture) { "customer.subscription.updated.api-v2019-12-03.json" }
+          describe ":products" do
+            subject(:products) { event[:products] }
+            describe "[0]" do
+              subject(:product) { products[0] }
+              describe ":subscription" do
+                subject(:subscription) { product[:subscription] }
+                it { is_expected.to include(period: { start: Time.at(1586329200), end: Time.at(1588921200) }) }
+                context 'when the subscription does not have a canceled_at value set' do
+                  let(:interpolate) { { data: { object: { canceled_at: nil } } } }
+                  it { is_expected.to include(status: :active) }
+                end
 
+                context 'when the subscription does have a canceled_at value set' do
+                  let(:interpolate) { { data: { object: { canceled_at: 1234 } } } }
+                  it { is_expected.to include(status: :canceled) }
+                end
+
+
+              end
+            end
+          end
+        end
         context "when the input event is JSON parsed from a Stripe customer.subscription.deleted event from Stripe API v2019-12-03" do
           let(:fixture) { "customer.subscription.deleted.api-v2019-12-03.json" }
           it { is_expected.to include raw_body: Compensated.json_adapter.dump(request.data) }

--- a/compensated-ruby/spec/stripe/fixtures/customer.subscription.deleted.api-v2019-12-03.json
+++ b/compensated-ruby/spec/stripe/fixtures/customer.subscription.deleted.api-v2019-12-03.json
@@ -12,7 +12,13 @@
       "billing_thresholds": null,
       "cancel_at": null,
       "cancel_at_period_end": false,
+      <% if interpolate.key?(:data_object_canceled_at) && interpolate[:data_object_canceled_at].nil? %>
+      "canceled_at": null,
+      <% elsif interpolate.key?(:data_object_canceled_at) %>
+      "canceled_at": <%= interpolate[:data_object_canceled_at] %>,
+      <% else %>
       "canceled_at": 1576716105,
+      <% end %>
       "collection_method": "charge_automatically",
       "created": 1576714588,
       "current_period_end": 1579392988,
@@ -23,7 +29,13 @@
       "default_source": null,
       "default_tax_rates": [],
       "discount": null,
+      <% if interpolate.key?(:data_object_ended_at) && interpolate[:data_object_ended_at].nil? %>
+      "ended_at": null,
+      <% elsif interpolate.key?(:data_object_ended_at) %>
+      "ended_at": <%= interpolate[:data_object_ended_at] %>,
+      <% else %>
       "ended_at": 1576716105,
+      <% end %>
       "items": {
         "object": "list",
         "data": [

--- a/compensated-ruby/spec/stripe/fixtures/customer.subscription.deleted.api-v2019-12-03.json
+++ b/compensated-ruby/spec/stripe/fixtures/customer.subscription.deleted.api-v2019-12-03.json
@@ -12,13 +12,7 @@
       "billing_thresholds": null,
       "cancel_at": null,
       "cancel_at_period_end": false,
-      <% if interpolate.key?(:data_object_canceled_at) && interpolate[:data_object_canceled_at].nil? %>
-      "canceled_at": null,
-      <% elsif interpolate.key?(:data_object_canceled_at) %>
-      "canceled_at": <%= interpolate[:data_object_canceled_at] %>,
-      <% else %>
-      "canceled_at": 1576716105,
-      <% end %>
+      "canceled_at": <%= value(within: [:data, :object, :canceled_at], default: 1576716105) %>,
       "collection_method": "charge_automatically",
       "created": 1576714588,
       "current_period_end": 1579392988,
@@ -29,13 +23,7 @@
       "default_source": null,
       "default_tax_rates": [],
       "discount": null,
-      <% if interpolate.key?(:data_object_ended_at) && interpolate[:data_object_ended_at].nil? %>
-      "ended_at": null,
-      <% elsif interpolate.key?(:data_object_ended_at) %>
-      "ended_at": <%= interpolate[:data_object_ended_at] %>,
-      <% else %>
-      "ended_at": 1576716105,
-      <% end %>
+      "ended_at": <%= value(within: [:data, :object, :ended_at], default: 1576716105) %>,
       "items": {
         "object": "list",
         "data": [

--- a/compensated-ruby/spec/stripe/fixtures/customer.subscription.updated.api-v2019-12-03.json
+++ b/compensated-ruby/spec/stripe/fixtures/customer.subscription.updated.api-v2019-12-03.json
@@ -12,7 +12,7 @@
       "billing_thresholds": null,
       "cancel_at": null,
       "cancel_at_period_end": false,
-      "canceled_at": null,
+      "canceled_at": <%= value(within: [:data, :object, :canceled_at], default: nil) %>,
       "collection_method": "charge_automatically",
       "created": 1581145200,
       "current_period_end": 1588921200,


### PR DESCRIPTION
While working with @etlund, we discovered that we do not currently handle
when a stripe event comes in withended_at or cancelled_at values.

We began to restructure the subscription data structure to include the
subscription period and status.

However as we were testing, we wanted to add a permutation test for
when the canceled_at was set but ended_at wasn't, which prompted
a desire to interpolate data in our specs so we don't have to copy-paste
the fixtures over and over.

We think that using ERB for now makes sense, since it's built into Ruby.

We also wound up doing a pretty major restructuring of the expectations 
in the rspec code so we could make smaller assertions for focused parts 
of the resulting data structure.