### PR TITLE
🚧✨ CLI app for forwarding formatted events

### DIFF
--- a/compensated-proxy/README.md
+++ b/compensated-proxy/README.md
@@ -27,7 +27,7 @@ verifies the signature of inbound payment processor events, reformats the
 events into the standardized Compensated event format, signs them, and
 forwards them on to your event listener endpoint.
 
-`$ compensated-proxy --forward-to https://example.com/your-event-listener`
+`$ compensated-proxy --forward-to=https://example.com/your-event-listener --payment-processors=stripe,apple_iap,gumroad`
 
 ## Development
 

--- a/compensated-proxy/exe/compensated-proxy
+++ b/compensated-proxy/exe/compensated-proxy
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = "Usage: compensated-proxy --forward-to=https://example.com/payment-event-handler --payment-processors=stripe"
+
+  opts.on("-fhttps://your.example.com/event-handler", "--forward-to=https://your.example.com/event-handler", "URL to forward reformatted payment events") do |forward_to|
+    options[:forward_to] = forward_to
+  end
+  opts.on("-pstripe,gumroad,apple_iap", "--payment-processors=stripe,gumroad,apple_iap", "The payment processors you want to format and forward") do |processors|
+    options[:payment_processors] = processors.split(',')
+  end
+
+  opts.on("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end.parse!
+
+
+port = ENV['PORT'] || 9292
+require 'rack'
+require_relative '../lib/compensated/proxy'
+options[:payment_processors].each do |payment_processor|
+  require "compensated/#{payment_processor}"
+end
+
+Rack::Server.start(
+  app: Rack::ShowExceptions.new(Rack::Lint.new(Compensated::Proxy.new(forward_to: options[:forward_to]))), Port: port
+)


### PR DESCRIPTION
This is still pretty rough, but the general bones are there.

You can now use the executable compensated-proxy in place of
writing your own forwarder in Ruby.

This should make it a bit easier for folks who _do not_ want
to write their entire application in Ruby to do use compensated for
reformatting payment, invoice and subscription related events across payment providers.