### PR TITLE
🎉💡📝✅ Sprout cucumber-js for system-testing compensated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 # Since we're only using node for test infras
 # it feels odd to check-in the package-lock.json
 package-lock.json
+
+# Probably don't want tmp files to persist between dev machines.
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .vscode
+# We don't check-in installed packages to Git.
+node_modules
+# Since we're only using node for test infras
+# it feels odd to check-in the package-lock.json
+package-lock.json

--- a/bin/setup
+++ b/bin/setup
@@ -20,3 +20,6 @@ else
   (cd compensated-proxy && bin/setup)
   (cd compensated-spec && bin/setup)
 fi
+
+# We use cucumber-js for system and integration testing
+npm install --save-dev cucumber

--- a/bin/setup
+++ b/bin/setup
@@ -22,4 +22,5 @@ else
 fi
 
 # We use cucumber-js for system and integration testing
-npm install --save-dev cucumber
+# We use `uuid` to generate random strings
+npm install --save-dev cucumber uuid

--- a/bin/test
+++ b/bin/test
@@ -20,3 +20,8 @@ else
   (cd compensated-proxy && bin/test)
   (cd compensated-spec && bin/test)
 fi
+
+echo "Running feature specs"
+# This skips the feature specs that are not wired in yet, are working on,
+# or have not been started yet.
+npx cucumber-js --tags "not @unwired and not @wip and not @later"

--- a/compensated-ruby/compensated.gemspec
+++ b/compensated-ruby/compensated.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|bin|examples)/}) }
   end
   spec.bindir = "exe"
-  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.executables << "compensated"
   spec.require_paths = ["lib"]
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/compensated-ruby/exe/compensated
+++ b/compensated-ruby/exe/compensated
@@ -1,0 +1,3 @@
+#!/usr/bin/env ruby
+
+puts "I AM A SCRIPT"

--- a/features/compensated-proxy.feature
+++ b/features/compensated-proxy.feature
@@ -1,3 +1,4 @@
+@unwired
 Feature: Forwarding Proxy
   In order to leverage Compensated's event standardization
   As a Client who doesn't use Ruby

--- a/features/cross-platform-selling.feature
+++ b/features/cross-platform-selling.feature
@@ -1,0 +1,34 @@
+Feature: Cross-Platform Selling
+  In order to maximize my income
+  I want to sell my products and services across channels
+
+
+  @wip @developer-persona @stripe
+  Scenario: Developer Creates Products and Prices in Stripe
+  Given Compensated is configured with a clean Stripe account
+  And there is a compensated.json with the following data:
+  """
+  {
+    "products": [
+      {
+        "name": "Robot Delivery",
+        "prices": [
+          { "nickname": "Small month-to-month", "amount": 10_00, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Small full-year", "amount": 100_00, "currency": "usd", "interval": "annual" },
+          { "nickname": "Medium month-to-month", "amount": 20_00, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Medium full-year", "amount": 200_00, "currency": "usd", "interval": "annual" },
+          { "nickname": "Large month-to-month", "amount": 40_00, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Large full-year", "amount": 400_00, "currency": "usd", "interval": "annual" }
+        ]
+      }
+    ]
+  }
+  """
+  When I run `compensated apply`
+  Then a "Robot Delivery" Product is created in Stripe
+  And the "Robot Delivery" Product has a "Small month-to-month" Price of $10 USD billed monthly in Stripe
+  And the "Robot Delivery" Product has a "Small full-year" Price of $100 USD billed annually in Stripe
+  And the "Robot Delivery" Product has a "Medium month-to-month" Price of $20 USD billed monthly in Stripe
+  And the "Robot Delivery" Product has a "Medium full-year" Price of $200 USD billed annually in Stripe
+  And the "Robot Delivery" Product has a "Large month-to-month" Price of $40 USD billed monthly in Stripe
+  And the "Robot Delivery" Product has a "Large full-year" Price of $400 USD billed annually in Stripe

--- a/features/parameter_types.js
+++ b/features/parameter_types.js
@@ -1,0 +1,35 @@
+const { defineParameterType } = require("cucumber");
+
+// Provides a programmatic interface for interacting with data
+// pull from the the {price} Cucumber Parameter Type
+class Price {
+  constructor(priceString) {
+    this.priceString = priceString;
+  }
+}
+Price.parser =  /\$?(\d+) (USD) billed (monthly|annually)/
+
+/*
+ * A custom Cucumber Parameter Type for reading Price data from steps.
+ *
+ * @see {@link https://cucumber.io/docs/cucumber/cucumber-expressions/#parameter-types}
+ */
+defineParameterType({
+  name: "price",
+  regexp: Price.parser,
+  transformer: (priceString) => new Price(priceString),
+});
+
+
+/*
+ * A Custom Parameter Type for Payment Gateways.
+ * At present, it doesn't transform into anything, but it could
+ * eventually.
+ *
+ * @see {@link https://cucumber.io/docs/cucumber/cucumber-expressions/#parameter-types}
+ */
+defineParameterType({
+  name: "paymentGateway",
+  regexp: /Stripe/,
+  transformer: (pg) => pg,
+});

--- a/features/sandbox.js
+++ b/features/sandbox.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+const { v4: uuidv4 } = require('uuid');
+
+
+/*
+ * A Sandbox lets us create and destroy our testing environment
+ * programmatically. At present, Compensated is a command-line
+ * program, so the sandbox is going to be a local directory on
+ * the filesystem that we can dump temporary files in.
+ */
+module.exports = class Sandbox {
+  constructor( paymentGateway) {
+    this.paymentGateway = paymentGateway
+    this.runId = uuidv4()
+
+    this.createTempDirectory()
+
+    this.createFileSync('Gemfile', gemfileTemplate)
+    this.executeSync(`bundle`)
+  }
+
+  /*
+   * The location where the Sandbox stores any files useful at runtime
+   */
+  get temporaryDirectory() {
+    return `${sandboxDir}/${this.paymentGateway}-${this.runId}`
+  }
+
+  /*
+   * Create a file in the test sandbox synchronously.
+   */
+  createFileSync(fileName, contents) {
+    return fs.writeFileSync(`${this.temporaryDirectory}/${fileName}`, contents)
+  }
+
+  /*
+   * Create a file in the test sandbox synchronously.
+   */
+  executeSync(command) {
+    return execSync(command, { cwd: this.temporaryDirectory })
+  }
+
+  createTempDirectory() {
+    if (!fs.existsSync(this.temporaryDirectory)){
+      fs.mkdirSync(this.temporaryDirectory);
+    }
+  }
+}
+
+// Location to store sandbox files
+const sandboxDir = './tmp';
+if (!fs.existsSync(sandboxDir)){
+  fs.mkdirSync(sandboxDir);
+}
+
+// Default gemfile for the compensated sandbox
+const gemfileTemplate =
+`
+source "https://rubygems.org"
+gem "compensated", path: "../../compensated-ruby"
+`

--- a/features/steps.js
+++ b/features/steps.js
@@ -1,19 +1,17 @@
 const { Given, When, Then } = require('cucumber')
+const Sandbox = require('./sandbox');
 
 Given('Compensated is configured with a clean {paymentGateway} account', function (paymentGateway) {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
+  return this.sandbox = new Sandbox(paymentGateway)
 });
 
-Given('there is a compensated.json with the following data:', function (docString) {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
+Given('there is a compensated.json with the following data:', function (json) {
+  return this.sandbox.createFileSync('compensated.json', json)
 });
 
 
 When('I run `compensated apply`', function () {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
+  return this.sandbox.executeSync('bundle exec compensated apply')
 });
 
 Then(

--- a/features/steps.js
+++ b/features/steps.js
@@ -1,0 +1,31 @@
+const { Given, When, Then } = require('cucumber')
+
+Given('Compensated is configured with a clean {paymentGateway} account', function (paymentGateway) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+Given('there is a compensated.json with the following data:', function (docString) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+
+When('I run `compensated apply`', function () {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});
+
+Then(
+  "the {string} Product has a {string} Price of {price} in {paymentGateway}",
+  function (productName, priceName, price, paymentGateway) {
+    // Write code here that turns the phrase above into concrete actions
+    return "pending";
+  }
+);
+
+
+Then('a {string} Product is created in {paymentGateway}', function (string, paymentGateway) {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});


### PR DESCRIPTION
See: https://github.com/zinc-collective/compensated/issues/79

I went back and forth between cucumber-js and cucumber-rb; and I wound
up choosing cucumber-js because JavaScript is the lingua-franca of the
web; and it seems like it makes it a bit easier for folks to get started
contributing to systems testing when we use a language that they're
familiar with.

This also adds the system tests to CI.

This could be merged as-is; but if it doesn't get merged I'll probably do a few more things:

- [x] Wire in the steps so it actually runs the compensated library when `compensated apply` gets called
- [ ] Figure out how to make assertions against a fake version of the Stripe API so we don't hit the real API in our tests.