### PR TITLE
`compensated apply` creates products and prices in Stripe

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/AccessModifierDeclarations:
+  Enabled: false

--- a/compensated-rails/spec/dummy/config/application.rb
+++ b/compensated-rails/spec/dummy/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'boot'
 
 require 'rails/all'
@@ -6,6 +8,7 @@ Bundler.require(*Rails.groups)
 require 'compensated/rails'
 
 module Dummy
+  # Example application for Spec purposes
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults Rails.version.slice(0, 3)

--- a/compensated-ruby/exe/compensated
+++ b/compensated-ruby/exe/compensated
@@ -1,3 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-puts "I AM A SCRIPT"
+require_relative '../lib/compensated/cli'
+
+Compensated::CLI.run(ARGV)

--- a/compensated-ruby/lib/compensated.rb
+++ b/compensated-ruby/lib/compensated.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 require_relative 'compensated/version'
+require_relative 'compensated/command'
 require_relative 'compensated/payment_processor_event_request_handler'
 
+# Automate payment related events and configuration across payment processors
 module Compensated
   class Error < StandardError; end
   class NoParserForEventError < Error; end

--- a/compensated-ruby/lib/compensated/cli.rb
+++ b/compensated-ruby/lib/compensated/cli.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'optparse'
+require 'compensated'
+
+module Compensated
+  # Contains the code related to running Compensated from the command line.
+  # Note: this module is _not_ included by default when you `require 'compensated'`
+  # However, it can be included if necessary via `require 'compensated/cli'
+  module CLI
+    def self.run(argv)
+      options = OptionsParser.new.options(argv)
+      Runner.new(options: options, command: ARGV[0]).run
+    end
+
+    # Runs the CLI by pulling together the configuration from the compensated.json
+    # file as well as ensuring the payment processors are loaded into the execution
+    # context.
+    class Runner
+      attr_accessor :options, :command
+      def initialize(options:, command:)
+        self.options = options
+        self.command = prepare_command(command)
+      end
+
+      def run
+        require_payment_processors
+        command.execute
+      end
+
+      private def require_payment_processors
+        config[:payment_processors].each do |payment_processor|
+          require "compensated/#{payment_processor}"
+        end
+      end
+
+      private def config
+        @config ||= Compensated.json_adapter.parse(File.read(File.absolute_path('compensated.json')))
+      end
+
+      private def prepare_command(command_name)
+        raise MissingCommandError unless command_name
+        return command_name if command_name.respond_to?(:execute)
+
+        case command_name
+        when 'apply'
+          ApplyCommand.new(options, config)
+        else
+          raise UnrecognizedCommandError, command_name
+        end
+      end
+    end
+
+    # Raised when no command is passed into the CLI.
+    class MissingCommandError < StandardError; end
+
+    # Raised when an unrecognized command is passed into the CLI
+    class UnrecognizedCommandError < StandardError; end
+
+    # Pulls the passed in options out of ARGV
+    class OptionsParser
+      # TODO: There may be some way to shift the responsibility for knowing which options
+      #      a particular payment adapter accepts into the paymnent adapters themselves.
+      OPTION_DEFINITIONS = [
+        {
+          options: ['--stripe-secret-key=STRIPE_SECRET_KEY'],
+          description: 'Secret key for Stripe. Defaults to the $STRIPE_SECRET_KEY environment variable.',
+          parser: ->(options, value, _opts = nil) { options[:stripe_secret_key] = value }
+        },
+        {
+          options: ['--stripe-publishable-key=STRIPE_PUBLISHABLE_KEY'],
+          description: 'Publishable key for Stripe. Defaults to the $STRIPE_PUBLISHABLE_KEY environment variable.',
+          parser: ->(options, value, _opts = nil) { options[:stripe_publishable_key] = value }
+        },
+        {
+          options: ['-h', '--help'],
+          description: 'Prints this help',
+          parser: lambda do |_options, _value, opts|
+            puts(opts)
+            exit
+          end
+        }
+      ].freeze
+
+      def options(argv)
+        options = default_options
+        OptionParser.new do |opts|
+          opts.banner = 'Usage: compensated [options]'
+          OPTION_DEFINITIONS.each do |option_definition|
+            opts.on(*(option_definition[:options] + [option_definition[:description]])) do |value|
+              option_definition[:parser].call(options, value, opts)
+            end
+          end
+        end.parse!(argv)
+        options
+      end
+
+      private def default_options
+        {
+          stripe_secret_key: ENV['STRIPE_SECRET_KEY'],
+          stripe_publishable_key: ENV['STRIPE_PUBLISHABLE_KEY']
+        }
+      end
+    end
+  end
+end

--- a/compensated-ruby/lib/compensated/command.rb
+++ b/compensated-ruby/lib/compensated/command.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Compensated
+  # Parent class for Commands. Commands are organized as a tree, with `Command` as
+  #  a trunk, with it's children for each command that can be executed by Compensated and
+  # TODO: Not sure if this is best with parent -> child inheritence or as a mixin.
+  #       Goal is to make it possible to have Commands that have different
+  #       implementations for each payment processor.
+  class Command
+    attr_accessor :options, :configuration
+
+    def initialize(options, configuration)
+      self.options = options
+      self.configuration = configuration
+    end
+
+    def execute
+      children.each do |child|
+        child.new(options, configuration).execute
+      end
+    end
+
+    def children
+      self.class.children_registry
+    end
+
+    def self.children_registry
+      @children_registry ||= []
+    end
+
+    def self.inherited(child)
+      children_registry << child
+    end
+  end
+
+  # Applies the Compensated configuration to each Payment Processor
+  # Individual Payment Processors Adapters should inherit from this
+  # class in order to support the Apply command
+  class ApplyCommand < Command; end
+end

--- a/compensated-ruby/lib/compensated/stripe.rb
+++ b/compensated-ruby/lib/compensated/stripe.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 require_relative 'stripe/version'
 require_relative 'stripe/event_parser'
+require_relative 'stripe/apply_command'
 
 module Compensated
   module Stripe

--- a/compensated-ruby/lib/compensated/stripe/apply_command.rb
+++ b/compensated-ruby/lib/compensated/stripe/apply_command.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+module Compensated
+  module Stripe
+    # Applys the Compensated Configuration to a Stripe account
+    class ApplyCommand < Compensated::ApplyCommand
+      API_URI = URI('https://api.stripe.com/v1/')
+      def execute
+        API_URI.user = options[:stripe_secret_key]
+        # https://stripe.com/docs/billing/prices-guide
+
+        Net::HTTP.start(API_URI.hostname, API_URI.port, use_ssl: true) do |http|
+          configuration[:products].each do |product_configuration|
+            product = find_or_create_product(product_configuration, http: http)
+            raise "Can't find/create product for #{product_configuration}" unless product
+
+            product_configuration[:prices].each do |price_configuration|
+              price = find_or_create_price(price_configuration, product: product, http: http)
+              raise "Can't find/create price #{price_configuration} for #{product_configuration}" unless price
+
+              # Assembled from
+              # https://stripe.com/docs/payments/checkout/client-subscription
+              # TODO: Move this to Compensated and/or Support
+              puts <<~DOCS
+                Congratulations! You're set up to sell Convene for $20.00/mo.
+                Embed the following HTML into your page!
+                ```
+                <script src="https://js.stripe.com/v3/"></script>
+                <script>
+                  var stripe = Stripe('#{options.fetch(:stripe_publishable_key, 'STRIPE_PUBLISHABLE_API_KEY')}');
+                  function beginPurchaseFlow() {
+                    stripe.redirectToCheckout({
+                      lineItems: [{
+                        // Replace with the ID of your price
+                        price: '#{price[:id]}',
+                        quantity: 1,
+                      }],
+                      mode: 'subscription',
+                      successUrl: 'https://example.com/success',
+                      cancelUrl: 'https://example.com/cancel',
+                    }).then(function (result) {
+                      // If `redirectToCheckout` fails due to a browser or network
+                      // error, display the localized error message to your customer
+                      // using `result.error.message`.
+                    });
+                  }
+                  window.addEventListener('DOMContentLoaded', (event) => {
+                    const beginPurchaseButtons = document.getElementsByClassName('begin-purchase-flow')
+                    for(const beginPurchaseButton of beginPurchaseButtons) {
+                      beginPurchaseButton.addEventListener('click', beginPurchaseFlow)
+                    }
+                  });
+                </script>
+                <button class="begin-purchase-flow">Buy Now</button>
+                ```
+              DOCS
+            end
+          end
+        end
+      end
+
+      def api_uri(path)
+        URI.join(API_URI, path)
+      end
+
+      def request(req, http:)
+        req.basic_auth options[:stripe_secret_key], ''
+        res = http.request(req)
+        JSON.parse(res.body, symbolize_names: true)
+      end
+
+      def get(path, http:)
+        request(Net::HTTP::Get.new(api_uri(path)), http: http)
+      end
+
+      def post(path, data, http:)
+        req = Net::HTTP::Post.new(api_uri(path))
+        req.form_data = data
+        request(req, http: http)
+      end
+
+      # TODO: Move this to Compensated
+      def find_or_create_product(product_configuration, http:)
+        response_body = get('products', http: http)
+        products = response_body[:data]
+
+        product = products.find { |product| product[:name] == product_configuration[:name] }
+        raise "Couldn't find product in first page of products..." if !product && response_body[:has_more]
+
+        product ||= post('products', { name: product_configuration[:name] }, http: http)
+      end
+
+      # TODO: Move this to Compensated
+      def find_or_create_price(price_configuration, product:, http:)
+        # https://stripe.com/docs/api/prices/list#list_prices
+        response_body = get('prices', http: http)
+        prices = response_body[:data]
+
+        price = prices.find do |potential_price|
+          potential_price[:product] == product[:id] &&
+            potential_price[:unit_amount] == price_configuration[:amount] &&
+            potential_price[:currency].to_sym == price_configuration[:currency].to_sym
+          potential_price[:recurring][:interval].to_sym == price_configuration[:interval].to_sym
+        end
+
+        raise "Couldn't find price in first page of prices..." if !price && response_body[:has_more]
+
+        post('prices', { product: product[:id],
+                         unit_amount: price_configuration[:amount],
+                         nickname: price_configuration[:nickname],
+                         currency: price_configuration[:currency],
+                         "recurring[interval]": price_configuration[:interval] },
+             http: http)
+      end
+    end
+  end
+end

--- a/features/cross-platform-selling.feature
+++ b/features/cross-platform-selling.feature
@@ -9,16 +9,17 @@ Feature: Cross-Platform Selling
   And there is a compensated.json with the following data:
   """
   {
+    "payment_processors": ["stripe"],
     "products": [
       {
         "name": "Robot Delivery",
         "prices": [
-          { "nickname": "Small month-to-month", "amount": 10_00, "currency": "usd", "interval": "monthly" },
-          { "nickname": "Small full-year", "amount": 100_00, "currency": "usd", "interval": "annual" },
-          { "nickname": "Medium month-to-month", "amount": 20_00, "currency": "usd", "interval": "monthly" },
-          { "nickname": "Medium full-year", "amount": 200_00, "currency": "usd", "interval": "annual" },
-          { "nickname": "Large month-to-month", "amount": 40_00, "currency": "usd", "interval": "monthly" },
-          { "nickname": "Large full-year", "amount": 400_00, "currency": "usd", "interval": "annual" }
+          { "nickname": "Small month-to-month", "amount": 1000, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Small full-year", "amount": 10000, "currency": "usd", "interval": "annual" },
+          { "nickname": "Medium month-to-month", "amount": 2000, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Medium full-year", "amount": 20000, "currency": "usd", "interval": "annual" },
+          { "nickname": "Large month-to-month", "amount": 4000, "currency": "usd", "interval": "monthly" },
+          { "nickname": "Large full-year", "amount": 40000, "currency": "usd", "interval": "annual" }
         ]
       }
     ]


### PR DESCRIPTION
See: https://github.com/zinc-collective/compensated/issues/79

The compensated cli now exists, and forwards options and configuration into
commands. Commands can be defined by extending the
`Compensated::Command` class, and overriding the `execute` method.

The first command is `apply`, which creates the configured products and
prices in the Payment Processors that support it.

This is a pretty-close to direct port of the code that I wrote to
allow folks to create products and prices in Stripe.

See: https://github.com/zinc-collective/convene/pull/26

Further, this gives us a `.rubocop.yml` file in the top level of the
project so that formatting can begin to become consistent across files.